### PR TITLE
fixup phpspec data provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,12 @@
     "autoload": {
         "psr-4": { "PUGX\\Poser\\": "src/" }
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/madisoft/phpspec-data-provider-extension"
+        }
+    ],
     "require": {
         "php": ">=7.4",
         "ext-gd": "*",
@@ -31,7 +37,8 @@
     "require-dev": {
         "phpspec/phpspec": "^6.1",
         "behat/behat": "^3.7",
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "moave/phpspec-data-provider-extension": "dev-master"
     },
     "config": {
         "bin-dir": "bin"

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,2 +1,3 @@
 extensions:
-#  - Coduo\PhpSpec\DataProvider\DataProviderExtension
+  Coduo\PhpSpec\DataProvider\DataProviderExtension: ~
+


### PR DESCRIPTION
[fixup/phpspec-data-provider 285cbd3] fixup phpspec data provider

Thanks @DonCallisto 

**Green tests again** 🚀 

```
$ docker-compose exec fpm bin/phpspec run --format=pretty

      PUGX\Poser\Badge

  11  ✔ is initializable (135ms)
  17  ✔ should be constructed by fromURI factory method
  28  ✔ should be constructed by fromURI factory method escaping correctly underscores
  40  ✔ should be constructed by fromURI factory method escaping correctly with single underscore
  52  ✔ should be constructed by fromURI factory method escaping correctly with dashes
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(11) "brightgreen"
  67  ✔ should validate available color schemes (92ms)
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(11) "brightgreen"
  67  ✔ 1) it should validate available color schemes
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(5) "green"
  67  ✔ 2) it should validate available color schemes
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(6) "yellow"
  67  ✔ 3) it should validate available color schemes
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(11) "yellowgreen"
  67  ✔ 4) it should validate available color schemes
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(6) "orange"
  67  ✔ 5) it should validate available color schemes
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(3) "red"
  67  ✔ 6) it should validate available color schemes
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(4) "blue"
  67  ✔ 7) it should validate available color schemes
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(4) "grey"
  67  ✔ 8) it should validate available color schemes
/application/spec/PUGX/Poser/BadgeSpec.php:69:
string(9) "lightgray"
  67  ✔ 9) it should validate available color schemes

      PUGX\Poser\Poser

  16  ✔ is initializable
  21  ✔ should be able to generate an svg image
  31  ✔ should be able to generate an svg image from URI

      PUGX\Poser\Render\SvgFlatRender

  18  ✔ should render a svg (70ms)
  36  ✔ should render a license mit exactly like this svg

      PUGX\Poser\Render\SvgFlatSquareRender

  18  ✔ should render a svg
  36  ✔ should render a license mit exactly like this svg

      PUGX\Poser\Render\SvgRender

  18  ✔ should render a svg
  24  ✔ should not render an invalid svg
  32  ✔ should not render non svg xml


5 specs
25 examples (25 passed)
907ms
```

@garak @AlessandroMinoccheri now we should make a decision: we use a fork by madisoft or we make a fork for pugx?