### PR TITLE
[2.x] Rename SvgRender to SvgPlasticRender

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Flush an image
 #### 2. Use in your project as lib
 
 ```php
-use PUGX\Poser\Render\SvgRender;
+use PUGX\Poser\Render\SvgPlasticRender;
 use PUGX\Poser\Poser;
 
-$render = new SvgRender();
+$render = new SvgPlasticRender();
 $poser = new Poser($render);
 
 echo $poser->generate('license', 'MIT', '428F7E', 'plastic');

--- a/spec/PUGX/Poser/Render/SvgPlasticRenderSpec.php
+++ b/spec/PUGX/Poser/Render/SvgPlasticRenderSpec.php
@@ -6,7 +6,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use PUGX\Poser\Badge;
 
-class SvgRenderSpec extends ObjectBehavior
+class SvgPlasticRenderSpec extends ObjectBehavior
 {
     public function let($calculator): void
     {

--- a/src/Render/SvgPlasticRender.php
+++ b/src/Render/SvgPlasticRender.php
@@ -12,12 +12,12 @@
 namespace PUGX\Poser\Render;
 
 /**
- * Class SvgGenerator.
+ * Class SvgPlasticGenerator.
  *
  * @author Claudio D'Alicandro <claudio.dalicandro@gmail.com>
  * @author Giulio De Donato <liuggio@gmail.com>
  */
-class SvgRender extends LocalSvgRenderer
+class SvgPlasticRender extends LocalSvgRenderer
 {
     /**
      * A list of all supported formats.

--- a/src/UI/Command.php
+++ b/src/UI/Command.php
@@ -6,7 +6,7 @@ use PUGX\Poser\Badge;
 use PUGX\Poser\Poser;
 use PUGX\Poser\Render\SvgFlatRender;
 use PUGX\Poser\Render\SvgFlatSquareRender;
-use PUGX\Poser\Render\SvgRender;
+use PUGX\Poser\Render\SvgPlasticRender;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,7 +32,7 @@ class Command extends BaseCommand
     private function init(): void
     {
         $this->poser = new Poser([
-            new SvgRender(),
+            new SvgPlasticRender(),
             new SvgFlatRender(),
             new SvgFlatSquareRender(),
         ]);


### PR DESCRIPTION
Rename `SvgRender` to `SvgPlasticRender` to follow same naming convention with `SvgFlatRender` & `SvgFlatSquareRender`.

Discussion started here: https://github.com/badges/poser/pull/33#issuecomment-661347229