### PR TITLE
[2.x] Remove svg format from SvgFlatRender

### DIFF
--- a/spec/PUGX/Poser/BadgeSpec.php
+++ b/spec/PUGX/Poser/BadgeSpec.php
@@ -10,13 +10,13 @@ class BadgeSpec extends ObjectBehavior
 {
     public function it_is_initializable(): void
     {
-        $this->beConstructedWith('a', 'b', '97CA00', 'svg');
+        $this->beConstructedWith('a', 'b', '97CA00', 'flat');
         $this->shouldHaveType('Pugx\Poser\Badge');
     }
 
     public function it_should_be_constructed_by_fromURI_factory_method(): void
     {
-        $this->beConstructedWith('a', 'b', '97CA00', 'svg');
+        $this->beConstructedWith('a', 'b', '97CA00', 'flat');
         $assert = 'version-stable-97CA00.svg';
         $it     = Badge::fromURI($assert);
 
@@ -27,7 +27,7 @@ class BadgeSpec extends ObjectBehavior
 
     public function it_should_be_constructed_by_fromURI_factory_method_escaping_correctly_underscores(): void
     {
-        $this->beConstructedWith('a', 'b', '97CA00', 'svg');
+        $this->beConstructedWith('a', 'b', '97CA00', 'flat');
         $input       = 'I__m__liugg__io-b-97CA00.svg';
         $assertInput = 'I_m_liugg_io-b-97CA00.svg';
         $it          = Badge::fromURI($input);
@@ -39,7 +39,7 @@ class BadgeSpec extends ObjectBehavior
 
     public function it_should_be_constructed_by_fromURI_factory_method_escaping_correctly_with_single_underscore(): void
     {
-        $this->beConstructedWith('a', 'b', '97CA00', 'svg');
+        $this->beConstructedWith('a', 'b', '97CA00', 'flat');
         $input       = 'I_m_liuggio-b-97CA00.svg';
         $assertInput = 'I m liuggio-b-97CA00.svg';
         $it          = Badge::fromURI($input);
@@ -51,7 +51,7 @@ class BadgeSpec extends ObjectBehavior
 
     public function it_should_be_constructed_by_fromURI_factory_method_escaping_correctly_with_dashes(): void
     {
-        $this->beConstructedWith('a', 'b', '97CA00', 'svg');
+        $this->beConstructedWith('a', 'b', '97CA00', 'flat');
         $input       = 'I--m--liuggio-b-97CA00.svg';
         $assertInput = 'I-m-liuggio-b-97CA00.svg';
         $it          = Badge::fromURI($input);
@@ -67,7 +67,7 @@ class BadgeSpec extends ObjectBehavior
     public function it_should_validate_available_color_schemes($colorName, $expectedValue): void
     {
         \var_dump($colorName);
-        $this->beConstructedWith('a', 'b', $colorName, 'svg');
+        $this->beConstructedWith('a', 'b', $colorName, 'flat');
         $this->getHexColor()->shouldBeString();
     }
 

--- a/spec/PUGX/Poser/PoserSpec.php
+++ b/spec/PUGX/Poser/PoserSpec.php
@@ -23,7 +23,7 @@ class PoserSpec extends ObjectBehavior
         $subject = 'stable';
         $status  = 'v2.0';
         $color   = '97CA00';
-        $format  = 'svg';
+        $format  = 'flat';
 
         $this->generate($subject, $status, $color, $format)->shouldBeAValidSVGImageContaining($subject, $status);
     }

--- a/src/Badge.php
+++ b/src/Badge.php
@@ -4,7 +4,7 @@ namespace PUGX\Poser;
 
 class Badge
 {
-    public const DEFAULT_FORMAT = 'svg';
+    public const DEFAULT_FORMAT = 'flat';
 
     private static array $colorScheme = [
         'brightgreen' => '44cc11',

--- a/src/Render/RenderInterface.php
+++ b/src/Render/RenderInterface.php
@@ -22,7 +22,7 @@ interface RenderInterface
     public function render(Badge $badge): Image;
 
     /**
-     * @return array the list of the supported format eg array('svg')
+     * @return array the list of the supported format eg array('flat')
      */
     public function supportedFormats(): array;
 }

--- a/src/Render/SvgFlatRender.php
+++ b/src/Render/SvgFlatRender.php
@@ -25,7 +25,7 @@ class SvgFlatRender extends LocalSvgRenderer
      */
     public function supportedFormats(): array
     {
-        return ['flat', 'svg'];
+        return ['flat'];
     }
 
     protected function getTemplateName(): string


### PR DESCRIPTION
Do we really need to have `svg` format here? All the renders are generating `svg` files. This format adds confusion.