### PR TITLE
[2.x] Add colors from shields.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * configure and run php-cs-fixer with new code style roles
 * add setting custom badge style from query string
 * add psalm
+* added all the colors from the shields.io site
 
 ### Changed
 * upgrade docker-compose for dev environment with php7.4

--- a/src/Badge.php
+++ b/src/Badge.php
@@ -9,7 +9,7 @@ class Badge
 
     private static array $colorScheme = [
         'brightgreen'   => '44cc11',
-        'green'         => '97CA00',
+        'green'         => '97ca00',
         'yellowgreen'   => 'a4a61d',
         'yellow'        => 'dfb317',
         'orange'        => 'fe7d37',
@@ -18,7 +18,7 @@ class Badge
         'lightgray'     => '9f9f9f',
         'grey'          => '555555',
         'blueviolet'    => '8a2be2',
-        'success'       => '97CA00',
+        'success'       => '97ca00',
         'important'     => 'fe7d37',
         'critical'      => 'e05d44',
         'informational' => '007ec6',

--- a/src/Badge.php
+++ b/src/Badge.php
@@ -8,15 +8,21 @@ class Badge
     public const DEFAULT_FORMAT = 'svg';
 
     private static array $colorScheme = [
-        'brightgreen' => '44cc11',
-        'green'       => '97CA00',
-        'yellow'      => 'dfb317',
-        'yellowgreen' => 'a4a61d',
-        'orange'      => 'fe7d37',
-        'red'         => 'e05d44',
-        'blue'        => '007ec6',
-        'grey'        => '555555',
-        'lightgray'   => '9f9f9f',
+        'brightgreen'   => '44cc11',
+        'green'         => '97CA00',
+        'yellowgreen'   => 'a4a61d',
+        'yellow'        => 'dfb317',
+        'orange'        => 'fe7d37',
+        'red'           => 'e05d44',
+        'blue'          => '007ec6',
+        'lightgray'     => '9f9f9f',
+        'grey'          => '555555',
+        'blueviolet'    => '8a2be2',
+        'success'       => '97CA00',
+        'important'     => 'fe7d37',
+        'critical'      => 'e05d44',
+        'informational' => '007ec6',
+        'inactive'      => '9f9f9f',
     ];
 
     private string $subject;


### PR DESCRIPTION
Added these colors to match shields.io color scheme:
```php
'blueviolet'    => '8a2be2',
'success'       => '97CA00',
'important'     => 'fe7d37',
'critical'      => 'e05d44',
'informational' => '007ec6',
'inactive'      => '9f9f9f',
```