### PR TITLE
Add lightgrey & gray badge colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]	
+## [Unreleased]
+
+### Added
+* lightgrey color to color scheme
+* grey color to color scheme
 
 ## [v2.0.1] - 2020-07-29
 

--- a/src/Badge.php
+++ b/src/Badge.php
@@ -16,6 +16,8 @@ class Badge
         'red'           => 'e05d44',
         'blue'          => '007ec6',
         'lightgray'     => '9f9f9f',
+        'lightgrey'     => '9f9f9f',
+        'gray'          => '555555',
         'grey'          => '555555',
         'blueviolet'    => '8a2be2',
         'success'       => '97ca00',


### PR DESCRIPTION
This PR resolves color names inconsistency described in #56

Adds `lightgrey` & `gray` colors.