### PR TITLE
Allow dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,5 +71,7 @@
         "branch-alias": {
             "dev-master": "2.x-dev"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
This might be useful on development phase, when we want to try some kind of untagged changes (from dev-master branch) of any package.

`"prefer-stable": true` will protect us install unstable packages if there are stable releases.